### PR TITLE
Exception: The official Pinecone python package has been renamed from `pinecone-client` to `pinecone`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ctransformers
 sentence-transformers
+pinecone
 pinecone-client
 langchain
 langchain-community


### PR DESCRIPTION
Fixes #4