### PR TITLE
ModuleNotFoundError: No module named 'langchain_pinecone'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pinecone
 pinecone-client
 langchain
 langchain-community
+langchain_pinecone
 flask
 pypdf
 python-dotenv


### PR DESCRIPTION
Fixes #5